### PR TITLE
Add ROS Bag Time to CSV

### DIFF
--- a/data_extractor_scripts/data_extractor.py
+++ b/data_extractor_scripts/data_extractor.py
@@ -7,6 +7,7 @@ from mcap_ros2.reader import read_ros2_messages
 
 
 def extract(topics, bag_file, csv_file):
+    # TODO: add ros bag time
     records = []
     ros_topics = list(map(lambda x: x.split(".")[0], topics))
     for msg in read_ros2_messages(bag_file, topics=ros_topics):


### PR DESCRIPTION
Add the ROS Bag time in seconds which can be used to plug into the rosbag `--start-offset` to make it easier to replay log files from the time period that we want."

this would be a change in the data extractor script